### PR TITLE
remove Mage_GoogleCheckout special function

### DIFF
--- a/src/app/code/community/Zookal/Mock/Model/Observer.php
+++ b/src/app/code/community/Zookal/Mock/Model/Observer.php
@@ -60,7 +60,6 @@ class Zookal_Mock_Model_Observer
         'Mage_Catalog'           => '_mageCatalog',
         'Mage_Customer'          => '_mageCustomer',
         'Mage_GiftMessage'       => '_mageMockHelperIncludePath',
-        'Mage_GoogleCheckout'    => '_mageGoogleCheckout',
         'Mage_Log'               => '_mageMockIncludePath',
         'Mage_ProductAlert'      => '_mageMockHelper',
         'Mage_Review'            => '_mageMockHelper',
@@ -134,23 +133,6 @@ class Zookal_Mock_Model_Observer
     protected function _mageMockIncludePath()
     {
         Mage::helper('zookal_mock')->setMockPhpIncludePath();
-    }
-
-    /**
-     * Special Handling when Mage_GoogleCheckout is disabled. It has a dependency in Mage_Sales/etc/config.xml :-(
-     *
-     * @param array $o
-     */
-    protected function _mageGoogleCheckout(array $o)
-    {
-        $prefixes = $this->_getAllPathPrefixes();
-        foreach ($prefixes as $prefix) {
-            $this->_setConfigNode($prefix . '/payment/' . $this->_mappingModel[$o['m']] . '/active', '0');
-            $this->_setConfigNode(
-                $prefix . '/payment/' . $this->_mappingModel[$o['m']] . '/model',
-                'zookal_mock/mocks_mage_payment'
-            );
-        }
     }
 
     /**


### PR DESCRIPTION
Mage_Sales does not have a dependency on Mage_GoogleCheckout anymore, at least not since 1.9.0.0, possibly earlier.

the workaround used has some side effects for extensions that make use of `Mage::helper('sales')->getPaymentMethods()`, as magento-mock only ads the code, "active" and "model". in our case, the (disabled) payment method was included in the configuration setting with `<source_model>adminhtml/system_config_source_payment_allmethods</source_model>` - as the title is not shown, it's listed at the top with an empty entry missleading the user.