### PR TITLE
skip manipulating payment/googlecheckout for recent magento versions

### DIFF
--- a/src/app/code/community/Zookal/Mock/Model/Observer.php
+++ b/src/app/code/community/Zookal/Mock/Model/Observer.php
@@ -143,6 +143,14 @@ class Zookal_Mock_Model_Observer
      */
     protected function _mageGoogleCheckout(array $o)
     {
+        // recent versions of Mage_Sales do not depend on Mage_GoolgeCheckout
+        if (method_exists('Mage', 'getEdition')){ // available from CE 1.7
+            if ((version_compare(Mage::getVersion(), '1.9.0.0', '>=') && (Mage::getEdition() == Mage::EDITION_COMMUNITY)) 
+                || (version_compare(Mage::getVersion(), '1.14.0.0', '>=') && (Mage::getEdition() == Mage::EDITION_ENTERPRISE))){
+                return;
+            }
+        }
+
         $prefixes = $this->_getAllPathPrefixes();
         foreach ($prefixes as $prefix) {
             $this->_setConfigNode($prefix . '/payment/' . $this->_mappingModel[$o['m']] . '/active', '0');


### PR DESCRIPTION
Mage_Sales does not have a dependency on Mage_GoogleCheckout anymore, at least not since 1.9.0.0, possibly earlier.

the workaround used has some side effects for extensions that make use of `Mage::helper('sales')->getPaymentMethods()`, as magento-mock only adds the code, "active" and "model". in our case, the (disabled) payment method was included in the configuration setting with `<source_model>adminhtml/system_config_source_payment_allmethods</source_model>` - as the title is not shown, it's listed at the top with an empty entry missleading the user.