### PR TITLE
Add shim to populate the visitor data if Mage_Log is disabled

### DIFF
--- a/src/app/code/community/Zookal/Mock/etc/config.xml
+++ b/src/app/code/community/Zookal/Mock/etc/config.xml
@@ -62,6 +62,16 @@
             </modules>
         </translate>
     </adminhtml>
+    <frontend>
+        <controller_action_postdispatch>
+            <observers>
+                <log>
+                    <class>zookal_mock/observer</class>
+                    <method>setupVisitorData</method>
+                </log>
+            </observers>
+        </controller_action_postdispatch>
+    </frontend>
     <default>
         <dev>
             <zookalmock>


### PR DESCRIPTION
Mage_Log is responsible for populating the visitor_data array in the
customer's session. This presents an issue with the SUPEE-10570 security
patch which relies on the customer_id being present in the visitor_data
array, which will not be present if Mage_Log is disabled.

This update ensures that the customer_id is set if the customer is
logged in and the Mage_Log module is disabled, preserving the
functionality introduced in SUPEE-10570 to log out all other sessions
after a customer resets their password.