### PR TITLE
Update the modman file to not use a wildcard

### DIFF
--- a/modman
+++ b/modman
@@ -1,3 +1,3 @@
-src/app/etc/modules/*					app/etc/modules/
-src/app/code/community/Zookal/Mock		app/code/community/Zookal/Mock
+src/app/etc/modules/Zookal_Mock.xml     app/etc/modules/Zookal_Mock.xml
+src/app/code/community/Zookal/Mock      app/code/community/Zookal/Mock
 src/app/locale/en_US/Zookal_Mock.csv    app/locale/en_US/Zookal_Mock.csv


### PR DESCRIPTION
The modman file references a wildcard for the modules xml, which in some
versions of the Magento composer installer would result in a gitignore
line being added for the entire app/etc/modules directory. The file has
been updated to explicitly reference the Zookal_Mock.xml file to ensure
that this never happens.